### PR TITLE
Update struts2 execute-method rule

### DIFF
--- a/rules/java/struts2/security/audit/entrypoints/execute-method.yml
+++ b/rules/java/struts2/security/audit/entrypoints/execute-method.yml
@@ -16,24 +16,19 @@ rules:
       - pattern-not: |
           class $CLASS extends ActionSupport {
             ...
-            $RETURN $METHOD() {
+            $RETURN execute() {
               ...
             }
             ...
           }
-      - patterns:
-          - pattern: |
-              class $CLASS {
-                ...
-                $RETURN $METHOD() {
-                  ...
-                }
-                ...
-              }
-      - metavariable-pattern:
-          metavariable: $METHOD
-          pattern: |
-            execute
+      - pattern: |
+          class $CLASS {
+            ...
+            $RETURN execute() {
+              ...
+            }
+            ...
+          }
 
       #- metavariable-regex:
       #    metavariable: $ANNOTATION


### PR DESCRIPTION
since the rule targets only one method (`execute()`) it is possible to avoid `metavariable-pattern` which should give better performance