### PR TITLE
Update XStream fromxml rule

### DIFF
--- a/rules/java/xstream/security/audit/fromxml.java
+++ b/rules/java/xstream/security/audit/fromxml.java
@@ -17,6 +17,42 @@ import org.springframework.context.annotation.Bean;
 
 import com.thoughtworks.xstream.XStream;
 
+public class FoobarXStream {
+
+    private XStream xstream = new XStream();
+
+    public FoobarXStream() {
+        
+        try {
+            // ruleid: fromXML
+            Object pq = xstream.fromXML(read);
+        } catch (Exception e) {
+            System.out.println(read);
+            System.out.println(e);
+        }
+    }
+
+}
+
+public class FoobarXStreamAgain {
+
+    private XStream xstream;
+
+    public FoobarXStreamAgain() {
+        xstream = new XStream();
+    }
+
+    public void doSmth() {
+        try {
+            // ruleid: fromXML
+            Object pq = xstream.fromXML(read);
+        } catch (Exception e) {
+            System.out.println(read);
+            System.out.println(e);
+        }
+    }
+}
+
 @SpringBootApplication
 public class Application {
 

--- a/rules/java/xstream/security/audit/fromxml.java
+++ b/rules/java/xstream/security/audit/fromxml.java
@@ -22,7 +22,7 @@ public class FoobarXStream {
     private XStream xstream = new XStream();
 
     public FoobarXStream() {
-        
+
         try {
             // ruleid: fromXML
             Object pq = xstream.fromXML(read);

--- a/rules/java/xstream/security/audit/fromxml.yml
+++ b/rules/java/xstream/security/audit/fromxml.yml
@@ -11,23 +11,7 @@ rules:
         - JVM
         - XML
         - XStream
-    patterns:
-      - pattern-inside: |
-          import com.thoughtworks.xstream.XStream;
-          ...
-      - pattern-either:
-          - patterns:
-              - pattern-inside: |
-                  $TYPE $XSTREAM = new com.thoughtworks.xstream.XStream(...);
-                  ...
-              - pattern: $XSTREAM.fromXML(...);
-          - pattern-inside: |
-              class $CLASS {
-                ...
-                $TYPE $XSTREAM = new com.thoughtworks.xstream.XStream(...);
-                ...
-              }
-          - pattern: $XSTREAM.fromXML(...);
+    pattern: (com.thoughtworks.xstream.XStream $XSTREAM).fromXML(...);
     message: >-
       XStream XML Deserialzation: Check that they have correctly set an allow-list and if an attacker can control input.
     severity: WARNING


### PR DESCRIPTION
Since the idea of the rule is to highlight all instances of `com.thoughtworks.xstream.XStream` that run `fromXML` method, it can be simplified without losing its scope.