### PR TITLE
fix unkown field metavariable-pattern warnings

### DIFF
--- a/rules-audit/csharp/dotnet/orm-leak/entity-framework-orm.yaml
+++ b/rules-audit/csharp/dotnet/orm-leak/entity-framework-orm.yaml
@@ -98,14 +98,14 @@ rules:
       confidence: LOW
     severity: INFO
     languages: [csharp]
-
-    pattern-either:
-      - pattern: $Q.OrderBy($ARG)
-      - pattern: $Q.OrderByDescending($ARG)
-
-    metavariable-pattern:
-      metavariable: $ARG
-      pattern-not: '"..."'
+    patterns:
+      - pattern-either:
+          - pattern: $Q.OrderBy($ARG)
+          - pattern: $Q.OrderByDescending($ARG)
+      - metavariable-pattern:
+          metavariable: $ARG
+          patterns:
+            - pattern-not: '"..."'
 
 
   - id: ef-ormleak-dynamic-where
@@ -131,11 +131,11 @@ rules:
       impact: MEDIUM
       confidence: LOW
     languages: [csharp]
-
-    pattern-either:
-      - pattern: $Q.Where($EXPR)
-      - pattern: $Q.Where($LAMBDA)
-
-    metavariable-pattern:
-      metavariable: $EXPR
-      pattern-not: $X => $X.$PROP $OP $VAR
+    patterns:
+      - pattern-either:
+          - pattern: $Q.Where($EXPR)
+          - pattern: $Q.Where($LAMBDA)
+      - metavariable-pattern:
+          metavariable: $EXPR
+          patterns:
+            - pattern-not: $X => $X.$PROP $OP $VAR

--- a/rules-audit/go/orm-leak/beego-orm.yaml
+++ b/rules-audit/go/orm-leak/beego-orm.yaml
@@ -122,15 +122,16 @@ rules:
       impact: MEDIUM
       confidence: LOW
     languages: [go]
-    pattern-either:
-      - pattern: $QS.Filter($EXPR, ...)
-      - pattern: $QS.Exclude($EXPR, ...)
-      - pattern: $COND.And($EXPR, ...)
-      - pattern: $COND.Or($EXPR, ...)
-    metavariable-pattern:
-      metavariable: $EXPR
-      patterns:
-        - pattern-not: '"..."'
+    patterns:
+      - pattern-either:
+          - pattern: $QS.Filter($EXPR, ...)
+          - pattern: $QS.Exclude($EXPR, ...)
+          - pattern: $COND.And($EXPR, ...)
+          - pattern: $COND.Or($EXPR, ...)
+      - metavariable-pattern:
+          metavariable: $EXPR
+          patterns:
+            - pattern-not: '"..."'
 
 
   - id: beego-ormleak-dynamic-orderby-review
@@ -156,8 +157,9 @@ rules:
       impact: MEDIUM
       confidence: LOW
     languages: [go]
-    pattern: $QS.OrderBy($EXPR, ...)
-    metavariable-pattern:
-      metavariable: $EXPR
-      patterns:
-        - pattern-not: '"..."'
+    patterns:
+      - pattern: $QS.OrderBy($EXPR, ...)
+      - metavariable-pattern:
+          metavariable: $EXPR
+          patterns:
+            - pattern-not: '"..."'


### PR DESCRIPTION
I was getting these warnings:
```
[00.10][WARNING]: Skipping unknown field 'metavariable-pattern' in rule "beego-ormleak-dynamic-expr-review"
[00.10][WARNING]: Skipping unknown field 'metavariable-pattern' in rule "beego-ormleak-dynamic-orderby-review"
[00.12][WARNING]: Skipping unknown field 'metavariable-pattern' in rule "ef-ormleak-dynamic-orderby"
[00.12][WARNING]: Skipping unknown field 'metavariable-pattern' in rule "ef-ormleak-dynamic-where"
```
Nesting the patterns under a patterns block fixes it 
relevant docs: https://semgrep.dev/docs/writing-rules/rule-syntax#optional